### PR TITLE
add customization for graphite plugin

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -48,7 +48,10 @@ default.influxdb.config = Mash.new ({
   },
   'input_plugins' => {
     'graphite' => {
-      'enabled' => false
+      'enabled' => false,
+      'port' => 2003,
+      'database' => 'graphite',
+      'udp_enabled' => false
     },
     'udp' => {
       'enabled' => false

--- a/templates/default/config.toml.erb
+++ b/templates/default/config.toml.erb
@@ -41,9 +41,9 @@ read-timeout = "<%= @config['api']['read-timeout'] %>"
   # Configure the graphite api
   [input_plugins.graphite]
   enabled = <%= @config['input_plugins']['graphite']['enabled'] %>
-  # port = 2003
-  # database = ""  # store graphite data in this database
-  # udp_enabled = true # enable udp interface on the same port as the tcp interface
+  port = <%= @config['input_plugins']['graphite']['port'] %>
+  database = "<%= @config['input_plugins']['graphite']['database'] %>"  # store graphite data in this database
+  udp_enabled = <%= @config['input_plugins']['graphite']['udp_enabled'] %> # enable udp interface on the same port as the tcp interface
 
   # Configure the udp api
   [input_plugins.udp]


### PR DESCRIPTION
This PR allow to customize graphite plugin for influxdb. The main reason is that without setting 'port' for plugin, influxdb does not start listen on port 2003.